### PR TITLE
fixed issue #9

### DIFF
--- a/congress/templates/congress/activities.html
+++ b/congress/templates/congress/activities.html
@@ -273,8 +273,8 @@ TODO
 									</a>
 								</div>
 							</div>
-							<p class="col s12 m12 l12" style="text-align:justify;margin-top:0px;margin-top:0px" class="secondary-text with-newlines">{{ speaker.bio }}</p>
 						</div>
+						<p class="col s12 m12 l12" style="text-align:justify;margin-top:0px;margin-top:0px" class="secondary-text with-newlines">{{ speaker.bio }}</p>
 					</div>
 
 


### PR DESCRIPTION
If the speaker has or hasn't a picture (doesn't matter), description will occupy 100% of the width.
issue #9
Before: in branch `develop`:
![da29c29f75fa38b05bd375eb51c783a7](https://user-images.githubusercontent.com/22072217/37121306-035d2822-225d-11e8-89f4-bd82e002ccf9.png)

After: in branch `issue_9`:
![da4382fbabf63c04587c8c84e4c2b6c9](https://user-images.githubusercontent.com/22072217/37120837-c41557b2-225b-11e8-935c-5fd9ab26f108.png)